### PR TITLE
Retrieve logger

### DIFF
--- a/box.go
+++ b/box.go
@@ -8,6 +8,13 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/ntp"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -23,12 +30,6 @@ import (
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-box/protocol/direct"
 	"github.com/sagernet/sing-box/route"
-	"github.com/sagernet/sing/common"
-	E "github.com/sagernet/sing/common/exceptions"
-	F "github.com/sagernet/sing/common/format"
-	"github.com/sagernet/sing/common/ntp"
-	"github.com/sagernet/sing/service"
-	"github.com/sagernet/sing/service/pause"
 )
 
 var _ adapter.Service = (*Box)(nil)
@@ -435,4 +436,8 @@ func (s *Box) Inbound() adapter.InboundManager {
 
 func (s *Box) Outbound() adapter.OutboundManager {
 	return s.outbound
+}
+
+func (s *Box) LogFactory() log.Factory {
+	return s.logFactory
 }

--- a/box.go
+++ b/box.go
@@ -8,13 +8,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/sagernet/sing/common"
-	E "github.com/sagernet/sing/common/exceptions"
-	F "github.com/sagernet/sing/common/format"
-	"github.com/sagernet/sing/common/ntp"
-	"github.com/sagernet/sing/service"
-	"github.com/sagernet/sing/service/pause"
-
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -30,6 +23,12 @@ import (
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-box/protocol/direct"
 	"github.com/sagernet/sing-box/route"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/ntp"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 )
 
 var _ adapter.Service = (*Box)(nil)

--- a/experimental/libbox/service.go
+++ b/experimental/libbox/service.go
@@ -92,6 +92,10 @@ func NewServiceWithContext(ctx context.Context, configContent string, platformIn
 	}, nil
 }
 
+func (s *BoxService) LogFactory() log.Factory {
+	return s.instance.LogFactory()
+}
+
 func (s *BoxService) Start() error {
 	if sFixAndroidStack {
 		var err error


### PR DESCRIPTION
This pull request introduces new logging capabilities to the `Box` and `BoxService` classes. The changes add methods to retrieve the `LogFactory` instance, which will facilitate logging within these classes.

Key changes include:

* [`box.go`](diffhunk://#diff-49667ef77d084a752fd8f74eeba19ed51a7c116320ac2a81384f61b25a00ebc9R439-R442): Added the `LogFactory` method to the `Box` struct to return the `logFactory` instance.
* [`experimental/libbox/service.go`](diffhunk://#diff-1816626f19a406cd70140c0a4def8087f3f2ce261c0516903b5beb52bb06545aR95-R98): Added the `LogFactory` method to the `BoxService` struct to return the `LogFactory` instance from the `Box` instance.