### PR TITLE
use log factory from ctx if it exists

### DIFF
--- a/box.go
+++ b/box.go
@@ -8,6 +8,13 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/ntp"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -23,12 +30,6 @@ import (
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-box/protocol/direct"
 	"github.com/sagernet/sing-box/route"
-	"github.com/sagernet/sing/common"
-	E "github.com/sagernet/sing/common/exceptions"
-	F "github.com/sagernet/sing/common/format"
-	"github.com/sagernet/sing/common/ntp"
-	"github.com/sagernet/sing/service"
-	"github.com/sagernet/sing/service/pause"
 )
 
 var _ adapter.Service = (*Box)(nil)
@@ -119,16 +120,20 @@ func New(options Options) (*Box, error) {
 	if platformInterface != nil {
 		defaultLogWriter = io.Discard
 	}
-	logFactory, err := log.New(log.Options{
-		Context:        ctx,
-		Options:        common.PtrValueOrDefault(options.Log),
-		Observable:     needClashAPI,
-		DefaultWriter:  defaultLogWriter,
-		BaseTime:       createdAt,
-		PlatformWriter: options.PlatformLogWriter,
-	})
-	if err != nil {
-		return nil, E.Cause(err, "create log factory")
+	logFactory := service.FromContext[log.Factory](ctx)
+	if logFactory == nil {
+		var err error
+		logFactory, err = log.New(log.Options{
+			Context:        ctx,
+			Options:        common.PtrValueOrDefault(options.Log),
+			Observable:     needClashAPI,
+			DefaultWriter:  defaultLogWriter,
+			BaseTime:       createdAt,
+			PlatformWriter: options.PlatformLogWriter,
+		})
+		if err != nil {
+			return nil, E.Cause(err, "create log factory")
+		}
 	}
 
 	routeOptions := common.PtrValueOrDefault(options.Route)


### PR DESCRIPTION
This pull request refactors the `New` function in `box.go` to first attempt retrieving `logFactory` from the context before falling back to creating a new `logFactory` instance. This change enhances flexibility by allowing the use of an existing log factory if provided in the context.

Relates to getlantern/engineering/issues/2237