### PR TITLE
Auto sync workflow

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -1,0 +1,28 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Runs every Monday at 00:00 UTC
+
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync fork with upstream
+        uses: tgymnich/fork-sync@v2.0.10
+        with:
+          # The owner of your forked repository
+          owner: getlantern
+          # The name of your forked repository
+          repo: sing-box-minimal
+          # The branch in forked repository to update
+          head: lantern-main
+          # The branch in the *upstream* repository to sync with
+          base: main
+          merge_method: merge
+          auto_merge: false
+          pr_title: 'Automated Fork Sync from Upstream'
+          pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing-box`.'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sing-box
 
+The `lantern-main` branch is our primary working branch. It will automatically be synced with `SagerNet/sing-box/main` on a weekly basis, but you can also trigger a manual sync by running the auto sync workflow.
+
+## 
+
 The universal proxy platform.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/sing-box.svg)](https://repology.org/project/sing-box/versions)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate syncing `lantern-main` with `SagerNet/sing-box/main` and updates the `README.md` to document this process. The workflow ensures that the fork remains up-to-date with the upstream changes on a weekly basis or when manually triggered. The most important changes are as follows:

### Automation of Fork Syncing:

* [`.github/workflows/autosync.yml`](diffhunk://#diff-b86ac34ab277f841784a9f4716c422e7df86d47bdc35aff4821fec82424c56acR1-R28): Added a new GitHub Actions workflow named "Sync Fork with Upstream" that runs weekly on Mondays at 00:00 UTC or can be triggered manually. It uses the `tgymnich/fork-sync` action to sync the `lantern-main` branch of the forked repository with the `main` branch of the upstream repository.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R6): Updated to include a description of the `lantern-main` branch as the primary working branch, noting that it is automatically synced with the upstream `main` branch weekly or can be synced manually via the workflow.