### PR TITLE
set automerge to true

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -23,6 +23,6 @@ jobs:
           # The name of the branch you want the changes pulled into.
           base: lantern-main
           merge_method: merge
-          auto_merge: false
+          auto_merge: true
           pr_title: 'Automated Fork Sync from Upstream'
           pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing-box`.'


### PR DESCRIPTION
This pull request includes a single change to the `.github/workflows/autosync.yml` file. The change enables automatic merging of pull requests by setting `auto_merge` to `true`.

* [`.github/workflows/autosync.yml`](diffhunk://#diff-b86ac34ab277f841784a9f4716c422e7df86d47bdc35aff4821fec82424c56acL26-R26): Updated the `auto_merge` property in the `jobs:` section from `false` to `true` to allow automatic merging of pull requests.