### PR TITLE
automatically request pr reviews

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Sync fork with upstream
-        uses: tgymnich/fork-sync@v2.0.10
+        uses: garmr-ulfr/fork-sync@request-pr-reviewers
         with:
           # The owner of your forked repository
           owner: getlantern
@@ -26,3 +26,4 @@ jobs:
           auto_merge: false
           pr_title: 'Automated Fork Sync from Upstream'
           pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing-box`.'
+          pr_reviewers: 'myleshorton,garmr-ulfr'


### PR DESCRIPTION
This pull request updates the `.github/workflows/autosync.yml` file to enhance the functionality of the fork synchronization workflow by switching to a custom fork-sync action and automatically assigning reviewers to pull requests.

Updates to the fork synchronization workflow:

* Added the `pr_reviewers` parameter to automatically assign reviewers (`myleshorton` and `garmr-ulfr`) to pull requests created by the sync process.