### PR TITLE
creating uapi listen function for windows and other unix implementations

### DIFF
--- a/transport/wireguard/endpoint.go
+++ b/transport/wireguard/endpoint.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sagernet/sing/service/pause"
 	"github.com/sagernet/wireguard-go/conn"
 	"github.com/sagernet/wireguard-go/device"
-	"github.com/sagernet/wireguard-go/ipc"
 
 	"go4.org/netipx"
 )
@@ -142,10 +141,6 @@ func (e *Endpoint) Start(resolve bool) error {
 	} else if resolve {
 		return nil
 	}
-	fileUAPI, uapiErr := ipc.UAPIOpen(e.options.Name)
-	if uapiErr != nil {
-		return fmt.Errorf("failed to open UAPI socket for %s: %w", e.options.Name, uapiErr)
-	}
 
 	var bind conn.Bind
 	wgListener, isWgListener := common.Cast[conn.Listener](e.options.Dialer)
@@ -185,7 +180,7 @@ func (e *Endpoint) Start(resolve bool) error {
 	}
 	wgDevice := device.NewDevice(e.options.Context, e.tunDevice, bind, logger, e.options.Workers)
 
-	uapi, err := ipc.UAPIListen(e.options.Name, fileUAPI)
+	uapi, err := uapiListen(e.options.Name)
 	if err != nil {
 		return fmt.Errorf("failed to listen on UAPI socket: %v", err)
 	}

--- a/transport/wireguard/uapi_other.go
+++ b/transport/wireguard/uapi_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package wireguard
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sagernet/wireguard-go/ipc"
+)
+
+func uapiListen(name string) (net.Listener, error) {
+	fileUAPI, uapiErr := ipc.UAPIOpen(name)
+	if uapiErr != nil {
+		return nil, fmt.Errorf("failed to open uapi socket for %s: %w", name, uapiErr)
+	}
+
+	uapi, err := ipc.UAPIListen(name, fileUAPI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on uapi socket: %v", err)
+	}
+	return uapi, nil
+}

--- a/transport/wireguard/uapi_windows.go
+++ b/transport/wireguard/uapi_windows.go
@@ -1,0 +1,16 @@
+package wireguard
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sagernet/wireguard-go/ipc"
+)
+
+func uapiListen(name string) (net.Listener, error) {
+	uapi, err := ipc.UAPIListen(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on uapi socket: %v", err)
+	}
+	return uapi, nil
+}


### PR DESCRIPTION
The wireguard-go windows implementation doesn't implement with the same function signature as other OS implementations for the IPC package, this commit is creating a listen function for windows and another for unix implementations with the hope that the IPC stuff is fixed. The windows IPC implementation create and manage pipe, the linux receive the pipe as a parameter