### PR TITLE
Make handshake reporting non-fatal for TCP and UDP connections

### DIFF
--- a/route/conn.go
+++ b/route/conn.go
@@ -82,13 +82,8 @@ func (m *ConnectionManager) NewConnection(ctx context.Context, this N.Dialer, co
 		m.logger.ErrorContext(ctx, err)
 		return
 	}
-	err = N.ReportConnHandshakeSuccess(conn, remoteConn)
-	if err != nil {
-		err = E.Cause(err, "report handshake success")
-		remoteConn.Close()
-		N.CloseOnHandshakeFailure(conn, onClose, err)
-		m.logger.ErrorContext(ctx, err)
-		return
+	if err = N.ReportConnHandshakeSuccess(conn, remoteConn); err != nil {
+		m.logger.ErrorContext(ctx, E.Cause(err, "report handshake success"))
 	}
 	if metadata.TLSFragment || metadata.TLSRecordFragment {
 		remoteConn = tf.NewConn(remoteConn, ctx, metadata.TLSFragment, metadata.TLSRecordFragment, metadata.TLSFragmentFallbackDelay)
@@ -169,12 +164,8 @@ func (m *ConnectionManager) NewPacketConnection(ctx context.Context, this N.Dial
 			return
 		}
 	}
-	err = N.ReportPacketConnHandshakeSuccess(conn, remotePacketConn)
-	if err != nil {
-		conn.Close()
-		remotePacketConn.Close()
+	if err = N.ReportPacketConnHandshakeSuccess(conn, remotePacketConn); err != nil {
 		m.logger.ErrorContext(ctx, "report handshake success: ", err)
-		return
 	}
 	if destinationAddress.IsValid() {
 		var originDestination M.Socksaddr


### PR DESCRIPTION
## Summary
- Handshake reporting errors (from tracker client info injection) no longer kill connections
- Fixes a bug where every UDP packet connection was terminated because `ReportPacketConnHandshakeSuccess` failed with "unsupported address" when fakeip DNS mapped destinations to domain names instead of IPs
- QUIC traffic (used heavily by Android for Google services) was completely broken, making the VPN appear connected but non-functional

## Root Cause
`lantern-box/tracker/clientcontext/injector.go:239` calls `conn.WriteTo(packet, metadata.Destination.UDPAddr())` where the destination is a fakeip domain (e.g. `android.apis.google.com:443`). `net.PacketConn.WriteTo` requires a `*net.UDPAddr` with an IP, not a domain — fails with "unsupported address".

The error propagated to `ConnectionManager.NewPacketConnection` which closed both ends of the connection and returned, preventing any data transfer.

## Fix
Both `NewConnection` (TCP) and `NewPacketConnection` (UDP) now log reporting errors but let the connection proceed. Tracker reporting is a side-channel concern and should never break user traffic.

## Test plan
- [ ] Verify VPN connectivity works on Android with fakeip DNS enabled
- [ ] Verify UDP/QUIC traffic flows (Google services, Play Store)
- [ ] Verify tracker client info still works for TCP connections
- [ ] Check that the "unsupported address" error is still logged (for future fix of the address resolution)

Fixes getlantern/engineering#3086
Freshdesk: https://lantern.freshdesk.com/a/tickets/170653

🤖 Generated with [Claude Code](https://claude.com/claude-code)