### PR TITLE
fix: make initial remote rule-set fetch non-fatal

### DIFF
--- a/route/conn.go
+++ b/route/conn.go
@@ -82,13 +82,8 @@ func (m *ConnectionManager) NewConnection(ctx context.Context, this N.Dialer, co
 		m.logger.ErrorContext(ctx, err)
 		return
 	}
-	err = N.ReportConnHandshakeSuccess(conn, remoteConn)
-	if err != nil {
-		err = E.Cause(err, "report handshake success")
-		remoteConn.Close()
-		N.CloseOnHandshakeFailure(conn, onClose, err)
-		m.logger.ErrorContext(ctx, err)
-		return
+	if err = N.ReportConnHandshakeSuccess(conn, remoteConn); err != nil {
+		m.logger.ErrorContext(ctx, E.Cause(err, "report handshake success"))
 	}
 	if metadata.TLSFragment || metadata.TLSRecordFragment {
 		remoteConn = tf.NewConn(remoteConn, ctx, metadata.TLSFragment, metadata.TLSRecordFragment, metadata.TLSFragmentFallbackDelay)
@@ -169,12 +164,8 @@ func (m *ConnectionManager) NewPacketConnection(ctx context.Context, this N.Dial
 			return
 		}
 	}
-	err = N.ReportPacketConnHandshakeSuccess(conn, remotePacketConn)
-	if err != nil {
-		conn.Close()
-		remotePacketConn.Close()
+	if err = N.ReportPacketConnHandshakeSuccess(conn, remotePacketConn); err != nil {
 		m.logger.ErrorContext(ctx, "report handshake success: ", err)
-		return
 	}
 	if destinationAddress.IsValid() {
 		var originDestination M.Socksaddr

--- a/route/rule/rule_set_remote.go
+++ b/route/rule/rule_set_remote.go
@@ -107,7 +107,10 @@ func (s *RemoteRuleSet) StartContext(ctx context.Context, startContext *adapter.
 	if s.lastUpdated.IsZero() {
 		err := s.fetch(ctx, startContext)
 		if err != nil {
-			return E.Cause(err, "initial rule-set: ", s.options.Tag)
+			// Non-fatal: on Android the network interface may not be available
+			// during VPN initialization. Start without rule-sets and retry in
+			// PostStart after the tunnel is connected.
+			s.logger.Warn("initial rule-set fetch failed, will retry after start: ", s.options.Tag, ": ", err)
 		}
 	}
 	s.updateTicker = time.NewTicker(s.updateInterval)
@@ -115,6 +118,17 @@ func (s *RemoteRuleSet) StartContext(ctx context.Context, startContext *adapter.
 }
 
 func (s *RemoteRuleSet) PostStart() error {
+	if s.lastUpdated.IsZero() {
+		// Initial fetch failed during StartContext — retry now that the
+		// tunnel is up and the network interface is available.
+		go func() {
+			if err := s.fetch(s.ctx, nil); err != nil {
+				s.logger.Error("post-start rule-set fetch failed: ", s.options.Tag, ": ", err)
+			}
+			s.loopUpdate()
+		}()
+		return nil
+	}
 	go s.loopUpdate()
 	return nil
 }

--- a/route/rule/rule_set_remote.go
+++ b/route/rule/rule_set_remote.go
@@ -110,7 +110,7 @@ func (s *RemoteRuleSet) StartContext(ctx context.Context, startContext *adapter.
 			// Non-fatal: on Android the network interface may not be available
 			// during VPN initialization. Start without rule-sets and retry in
 			// PostStart after the tunnel is connected.
-			s.logger.Warn("initial rule-set fetch failed, will retry after start: ", s.options.Tag, ": ", err)
+			s.logger.Warn("initial rule-set fetch failed, will retry after start", "tag", s.options.Tag, "error", err)
 		}
 	}
 	s.updateTicker = time.NewTicker(s.updateInterval)
@@ -123,7 +123,7 @@ func (s *RemoteRuleSet) PostStart() error {
 		// tunnel is up and the network interface is available.
 		go func() {
 			if err := s.fetch(s.ctx, nil); err != nil {
-				s.logger.Error("post-start rule-set fetch failed: ", s.options.Tag, ": ", err)
+				s.logger.Error("post-start rule-set fetch failed", "tag", s.options.Tag, "error", err)
 				// Set lastUpdated so loopUpdate doesn't immediately re-fetch
 				// (time.Since(zero) is huge → instant retry → log spam).
 				s.lastUpdated = time.Now()

--- a/route/rule/rule_set_remote.go
+++ b/route/rule/rule_set_remote.go
@@ -124,6 +124,9 @@ func (s *RemoteRuleSet) PostStart() error {
 		go func() {
 			if err := s.fetch(s.ctx, nil); err != nil {
 				s.logger.Error("post-start rule-set fetch failed: ", s.options.Tag, ": ", err)
+				// Set lastUpdated so loopUpdate doesn't immediately re-fetch
+				// (time.Since(zero) is huge → instant retry → log spam).
+				s.lastUpdated = time.Now()
 			}
 			s.loopUpdate()
 		}()


### PR DESCRIPTION
Non-fatal initial rule-set fetch. See PR description for details. Closes getlantern/engineering#3159