### PR TITLE
fix: make initial remote rule-set fetch non-fatal

### DIFF
--- a/route/rule/rule_set_remote.go
+++ b/route/rule/rule_set_remote.go
@@ -107,7 +107,10 @@ func (s *RemoteRuleSet) StartContext(ctx context.Context, startContext *adapter.
 	if s.lastUpdated.IsZero() {
 		err := s.fetch(ctx, startContext)
 		if err != nil {
-			return E.Cause(err, "initial rule-set: ", s.options.Tag)
+			// Non-fatal: on Android the network interface may not be available
+			// during VPN initialization. Start without rule-sets and retry in
+			// PostStart after the tunnel is connected.
+			s.logger.Warn("initial rule-set fetch failed, will retry after start: ", s.options.Tag, ": ", err)
 		}
 	}
 	s.updateTicker = time.NewTicker(s.updateInterval)
@@ -115,6 +118,17 @@ func (s *RemoteRuleSet) StartContext(ctx context.Context, startContext *adapter.
 }
 
 func (s *RemoteRuleSet) PostStart() error {
+	if s.lastUpdated.IsZero() {
+		// Initial fetch failed during StartContext — retry now that the
+		// tunnel is up and the network interface is available.
+		go func() {
+			if err := s.fetch(s.ctx, nil); err != nil {
+				s.logger.Error("post-start rule-set fetch failed: ", s.options.Tag, ": ", err)
+			}
+			s.loopUpdate()
+		}()
+		return nil
+	}
 	go s.loopUpdate()
 	return nil
 }

--- a/route/rule/rule_set_remote.go
+++ b/route/rule/rule_set_remote.go
@@ -124,6 +124,9 @@ func (s *RemoteRuleSet) PostStart() error {
 		go func() {
 			if err := s.fetch(s.ctx, nil); err != nil {
 				s.logger.Error("post-start rule-set fetch failed: ", s.options.Tag, ": ", err)
+				// Set lastUpdated so loopUpdate doesn't immediately re-fetch
+				// (time.Since(zero) is huge → instant retry → log spam).
+				s.lastUpdated = time.Now()
 			}
 			s.loopUpdate()
 		}()


### PR DESCRIPTION
## Summary
On Android, the network interface isn't available during VPN initialization, causing remote rule-set fetches (e.g. `common.srs` from GitHub) to fail. Previously this was **fatal** — the VPN refused to start.

Now the initial fetch is non-fatal: logs a warning and starts without rule-sets. `PostStart` retries after the tunnel is connected.

## Root cause
- lantern-cloud migration 000067 added direct smart routing rules for uncensored countries referencing `common.srs`
- lantern-cloud PR #2518 fixed the missing `Outbounds` field, causing rules to be included in config for the first time
- sing-box tries to fetch `.srs` during `StartContext` via `direct` detour
- On Android, the physical network is disrupted during VPN setup → fetch fails → fatal error

## Changes
- `StartContext`: if initial fetch fails, log warning and continue
- `PostStart`: if `lastUpdated` is zero (fetch failed), retry immediately; set `lastUpdated` on failure to prevent log spam from `loopUpdate`

Closes getlantern/engineering#3159
Replaces #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)