### PR TITLE
route: seed interface list from platform at NetworkManager.Start

### DIFF
--- a/route/network.go
+++ b/route/network.go
@@ -145,6 +145,21 @@ func (r *NetworkManager) Start(stage adapter.StartStage) error {
 			if err != nil {
 				return err
 			}
+			// Seed the interface list synchronously from the platform on
+			// platform-backed monitors (Android/iOS). Without this, the
+			// NetworkManager only learns about interfaces via the platform's
+			// change callback — but on Android the ConnectivityManager
+			// NetworkCallback does not fire onAvailable for networks that
+			// were already connected before the callback was registered.
+			// Result: after a VPN stop→start cycle wlan0/ccmni are absent
+			// from the interface list, so outbound/direct dials fail with
+			// "no available network interface" until some unrelated network
+			// event finally triggers an update. See Freshdesk #173507.
+			if r.platformInterface != nil {
+				if err := r.UpdateInterfaces(); err != nil {
+					r.logger.Warn("initial interface seed: ", err)
+				}
+			}
 		}
 	case adapter.StartStateStart:
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Fixes a flood of 'no available network interface' errors after VPN stop→start cycles on Android (Freshdesk #173507).

## Root cause

On Android, sing-box's NetworkManager relies on `ConnectivityManager.NetworkCallback` to learn about available interfaces. That callback only fires on network changes — not for networks already connected at registration. After a VPN stop→start, the new sing-box registers its callback but Android never re-fires `onAvailable(wlan0)` because wlan0 is already up, so the interface list stays empty. Every `outbound/direct` dial then fails in `dialer.dialParallelInterface` with 'no available network interface'. Fronted/kindling spam this path for CDN masquerades → 24,500 errors in 3 minutes in #173507.

## Fix

After `interfaceMonitor.Start()` succeeds during `StartStateInitialize`, call `r.UpdateInterfaces()` once for platform-backed monitors. `UpdateInterfaces` synchronously queries `platform.GetInterfaces()` (Android → `ConnectivityManager.getAllNetworks()`) and populates `interfaceFinder` + `networkInterfaces` immediately. No-op on non-platform monitors because `tun.NewNetworkUpdateMonitor` already emits at startup.

## Test plan

- [x] `./route/` and `./experimental/libbox/` build clean
- [ ] Android E2E: start→stop→start VPN, verify no 'no available network interface' flood
- [ ] Regression: non-Android unaffected (gated on `r.platformInterface != nil`)