### PR TITLE
feat(adapter): add Registered getter to registries

### DIFF
--- a/adapter/dns.go
+++ b/adapter/dns.go
@@ -78,6 +78,7 @@ type LegacyDNSTransport interface {
 
 type DNSTransportRegistry interface {
 	option.DNSTransportOptionsRegistry
+	Registry
 	CreateDNSTransport(ctx context.Context, logger log.ContextLogger, tag string, transportType string, options any) (DNSTransport, error)
 }
 

--- a/adapter/endpoint.go
+++ b/adapter/endpoint.go
@@ -16,6 +16,7 @@ type Endpoint interface {
 
 type EndpointRegistry interface {
 	option.EndpointOptionsRegistry
+	Registry
 	Create(ctx context.Context, router Router, logger log.ContextLogger, tag string, endpointType string, options any) (Endpoint, error)
 }
 

--- a/adapter/endpoint/registry.go
+++ b/adapter/endpoint/registry.go
@@ -2,6 +2,8 @@ package endpoint
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -69,4 +71,8 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 	defer m.access.Unlock()
 	m.optionsType[outboundType] = optionsConstructor
 	m.constructor[outboundType] = constructor
+}
+
+func (m *Registry) Registered() []string {
+	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/adapter/endpoint/registry.go
+++ b/adapter/endpoint/registry.go
@@ -74,5 +74,7 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 }
 
 func (m *Registry) Registered() []string {
+	m.access.Lock()
+	defer m.access.Unlock()
 	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/adapter/inbound.go
+++ b/adapter/inbound.go
@@ -31,6 +31,7 @@ type UDPInjectableInbound interface {
 
 type InboundRegistry interface {
 	option.InboundOptionsRegistry
+	Registry
 	Create(ctx context.Context, router Router, logger log.ContextLogger, tag string, inboundType string, options any) (Inbound, error)
 }
 

--- a/adapter/inbound/registry.go
+++ b/adapter/inbound/registry.go
@@ -2,6 +2,8 @@ package inbound
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -69,4 +71,8 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 	defer m.access.Unlock()
 	m.optionsType[outboundType] = optionsConstructor
 	m.constructor[outboundType] = constructor
+}
+
+func (m *Registry) Registered() []string {
+	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/adapter/inbound/registry.go
+++ b/adapter/inbound/registry.go
@@ -74,5 +74,7 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 }
 
 func (m *Registry) Registered() []string {
+	m.access.Lock()
+	defer m.access.Unlock()
 	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/adapter/outbound.go
+++ b/adapter/outbound.go
@@ -20,6 +20,7 @@ type Outbound interface {
 
 type OutboundRegistry interface {
 	option.OutboundOptionsRegistry
+	Registry
 	CreateOutbound(ctx context.Context, router Router, logger log.ContextLogger, tag string, outboundType string, options any) (Outbound, error)
 }
 

--- a/adapter/outbound/registry.go
+++ b/adapter/outbound/registry.go
@@ -74,5 +74,7 @@ func (r *Registry) register(outboundType string, optionsConstructor optionsConst
 }
 
 func (r *Registry) Registered() []string {
+	r.access.Lock()
+	defer r.access.Unlock()
 	return slices.Collect(maps.Keys(r.constructors))
 }

--- a/adapter/outbound/registry.go
+++ b/adapter/outbound/registry.go
@@ -2,6 +2,8 @@ package outbound
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -69,4 +71,8 @@ func (r *Registry) register(outboundType string, optionsConstructor optionsConst
 	defer r.access.Unlock()
 	r.optionsType[outboundType] = optionsConstructor
 	r.constructors[outboundType] = constructor
+}
+
+func (r *Registry) Registered() []string {
+	return slices.Collect(maps.Keys(r.constructors))
 }

--- a/adapter/registry.go
+++ b/adapter/registry.go
@@ -1,0 +1,5 @@
+package adapter
+
+type Registry interface {
+	Registered() []string
+}

--- a/adapter/service.go
+++ b/adapter/service.go
@@ -15,6 +15,7 @@ type Service interface {
 
 type ServiceRegistry interface {
 	option.ServiceOptionsRegistry
+	Registry
 	Create(ctx context.Context, logger log.ContextLogger, tag string, serviceType string, options any) (Service, error)
 }
 

--- a/adapter/service/registry.go
+++ b/adapter/service/registry.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -69,4 +71,8 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 	defer m.access.Unlock()
 	m.optionsType[outboundType] = optionsConstructor
 	m.constructor[outboundType] = constructor
+}
+
+func (m *Registry) Registered() []string {
+	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/adapter/service/registry.go
+++ b/adapter/service/registry.go
@@ -74,5 +74,7 @@ func (m *Registry) register(outboundType string, optionsConstructor optionsConst
 }
 
 func (m *Registry) Registered() []string {
+	m.access.Lock()
+	defer m.access.Unlock()
 	return slices.Collect(maps.Keys(m.constructor))
 }

--- a/dns/transport_registry.go
+++ b/dns/transport_registry.go
@@ -74,5 +74,7 @@ func (r *TransportRegistry) register(transportType string, optionsConstructor op
 }
 
 func (r *TransportRegistry) Registered() []string {
+	r.access.Lock()
+	defer r.access.Unlock()
 	return slices.Collect(maps.Keys(r.constructors))
 }

--- a/dns/transport_registry.go
+++ b/dns/transport_registry.go
@@ -2,6 +2,8 @@ package dns
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -69,4 +71,8 @@ func (r *TransportRegistry) register(transportType string, optionsConstructor op
 	defer r.access.Unlock()
 	r.optionsType[transportType] = optionsConstructor
 	r.constructors[transportType] = constructor
+}
+
+func (r *TransportRegistry) Registered() []string {
+	return slices.Collect(maps.Keys(r.constructors))
 }


### PR DESCRIPTION
This pull request introduces a unified `Registry` interface across multiple adapter registries, allowing for consistent retrieval of registered types. It adds a `Registered()` method to each registry, enabling clients to list all registered types (such as endpoints, inbounds, outbounds, services, and DNS transports). Additionally, the implementation leverages Go's `maps` and `slices` packages for concise collection handling.

**Registry interface standardization:**

* Introduced a new `Registry` interface in `adapter/registry.go` with a `Registered() []string` method for listing registered types.
* Updated all major registry interfaces (`EndpointRegistry`, `InboundRegistry`, `OutboundRegistry`, `ServiceRegistry`, `DNSTransportRegistry`) to embed the new `Registry` interface, ensuring a consistent API for querying registered types. [[1]](diffhunk://#diff-d920d2db6a29cfc16281fbe87ee7b303f192c3408722b87c0c41c0af95eaff24R19) [[2]](diffhunk://#diff-bfd0e46337b991cdfce1cc67237dd7a0f163e517428240e00dbb5ec42ec66dadR34) [[3]](diffhunk://#diff-e83db0b46e3876b9adcd6da476f8fb97c7459ff60576df357a32d7904322ec4dR23) [[4]](diffhunk://#diff-145bd700007ad818c58743f494ae1df31b3b92d901e04348998cd1c2a8ac0adcR18) [[5]](diffhunk://#diff-eff243c32326f3e15642ba02a777a6115b9ac5f87f9717f251c2e3ee7c8d74e9R81)

**Implementation of Registered() method:**

* Added a `Registered()` method to each registry implementation (`adapter/endpoint/registry.go`, `adapter/inbound/registry.go`, `adapter/outbound/registry.go`, `adapter/service/registry.go`, `dns/transport_registry.go`) to return a list of registered type names using `maps.Keys` and `slices.Collect`. [[1]](diffhunk://#diff-33a6411b053b4611519460b9cd2f2784406b9ceb35fc50141b60d16423560561R75-R78) [[2]](diffhunk://#diff-ab2f8e14788fbbdf526c830063094bdb389242bde665858a1a4bb05d9f4c82a7R75-R78) [[3]](diffhunk://#diff-a592e79eff97375d08be4a1137d95ca540c0594d4b929e03231f3d093f57a0f2R75-R78) [[4]](diffhunk://#diff-7b7c6885ca6883ed0ec249154dff9bc8861b5388e92efe926414da32e5294584R75-R78) [[5]](diffhunk://#diff-e4f2dfe57484f6b7a9495914d0c43adda45d951abfece6344186bf844c96e03cR75-R78)

**Dependency improvements:**

* Imported Go's `maps` and `slices` packages in registry files to simplify and modernize collection handling for the new `Registered()` methods. [[1]](diffhunk://#diff-33a6411b053b4611519460b9cd2f2784406b9ceb35fc50141b60d16423560561R5-R6) [[2]](diffhunk://#diff-ab2f8e14788fbbdf526c830063094bdb389242bde665858a1a4bb05d9f4c82a7R5-R6) [[3]](diffhunk://#diff-a592e79eff97375d08be4a1137d95ca540c0594d4b929e03231f3d093f57a0f2R5-R6) [[4]](diffhunk://#diff-7b7c6885ca6883ed0ec249154dff9bc8861b5388e92efe926414da32e5294584R5-R6) [[5]](diffhunk://#diff-e4f2dfe57484f6b7a9495914d0c43adda45d951abfece6344186bf844c96e03cR5-R6)