### PR TITLE
fix: don't panic in Manager.Remove when racing Close

### DIFF
--- a/adapter/endpoint/manager.go
+++ b/adapter/endpoint/manager.go
@@ -95,12 +95,18 @@ func (m *Manager) Remove(tag string) error {
 		m.access.Unlock()
 		return os.ErrInvalid
 	}
-	delete(m.endpointByTag, tag)
 	index := common.Index(m.endpoints, func(it adapter.Endpoint) bool {
 		return it == endpoint
 	})
+	delete(m.endpointByTag, tag)
 	if index == -1 {
-		panic("invalid endpoint index")
+		// Close() nils the endpoints slice but leaves endpointByTag populated,
+		// so a removal racing shutdown finds the tag with no slice entry. The
+		// endpoint is already closed (or being closed) by Close(); dropping
+		// the map entry is all that's left to do.
+		m.logger.Debug("endpoint/", endpoint.Type(), "[", tag, "] already removed from active list")
+		m.access.Unlock()
+		return nil
 	}
 	m.endpoints = append(m.endpoints[:index], m.endpoints[index+1:]...)
 	started := m.started
@@ -136,10 +142,9 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 		existsIndex := common.Index(m.endpoints, func(it adapter.Endpoint) bool {
 			return it == existsEndpoint
 		})
-		if existsIndex == -1 {
-			panic("invalid endpoint index")
+		if existsIndex != -1 {
+			m.endpoints = append(m.endpoints[:existsIndex], m.endpoints[existsIndex+1:]...)
 		}
-		m.endpoints = append(m.endpoints[:existsIndex], m.endpoints[existsIndex+1:]...)
 	}
 	m.endpoints = append(m.endpoints, endpoint)
 	m.endpointByTag[tag] = endpoint

--- a/adapter/endpoint/manager.go
+++ b/adapter/endpoint/manager.go
@@ -103,10 +103,9 @@ func (m *Manager) Remove(tag string) error {
 	})
 	delete(m.endpointByTag, tag)
 	if index == -1 {
-		// Close() nils the endpoints slice but leaves endpointByTag populated,
-		// so a removal racing shutdown finds the tag with no slice entry. The
-		// endpoint is already closed (or being closed) by Close(); dropping
-		// the map entry is all that's left to do.
+		// Defense in depth: the tag is in the map but not the slice. No code
+		// path should produce this state (Close clears both together), but if
+		// it ever reappears, heal the stale map entry instead of panicking.
 		m.logger.Debug("endpoint/", endpoint.Type(), "[", tag, "] already removed from active list")
 		m.access.Unlock()
 		return nil

--- a/adapter/endpoint/manager.go
+++ b/adapter/endpoint/manager.go
@@ -63,6 +63,9 @@ func (m *Manager) Close() error {
 	m.started = false
 	endpoints := m.endpoints
 	m.endpoints = nil
+	// Keep the map in sync with the slice: leaving stale entries behind is
+	// what made Remove racing Close find a tag with no slice entry.
+	clear(m.endpointByTag)
 	monitor := taskmonitor.New(m.logger, C.StopTimeout)
 	var err error
 	for _, endpoint := range endpoints {

--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -167,6 +167,9 @@ func (m *Manager) Close() error {
 	m.started = false
 	outbounds := m.outbounds
 	m.outbounds = nil
+	// Keep the map in sync with the slice: leaving stale entries behind is
+	// what made Remove racing Close find a tag with no slice entry.
+	clear(m.outboundByTag)
 	m.access.Unlock()
 	var err error
 	for _, outbound := range outbounds {

--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -218,10 +218,9 @@ func (m *Manager) Remove(tag string) error {
 	})
 	delete(m.outboundByTag, tag)
 	if index == -1 {
-		// Close() nils the outbounds slice but leaves outboundByTag populated,
-		// so a removal racing shutdown finds the tag with no slice entry. The
-		// outbound is already closed (or being closed) by Close(); dropping
-		// the map entry is all that's left to do.
+		// Defense in depth: the tag is in the map but not the slice. No code
+		// path should produce this state (Close clears both together), but if
+		// it ever reappears, heal the stale map entry instead of panicking.
 		m.logger.Debug("outbound/", outbound.Type(), "[", tag, "] already removed from active list")
 		return nil
 	}
@@ -239,8 +238,17 @@ func (m *Manager) Remove(tag string) error {
 	if len(dependBy) > 0 {
 		return E.New("outbound[", tag, "] is depended by ", strings.Join(dependBy, ", "))
 	}
-	dependencies := outbound.Dependencies()
-	for _, dependency := range dependencies {
+	m.removeDependByEntriesLocked(outbound, tag)
+	if started {
+		return common.Close(outbound)
+	}
+	return nil
+}
+
+// removeDependByEntriesLocked drops tag from the dependBy lists of outbound's
+// dependencies. Callers must hold m.access.
+func (m *Manager) removeDependByEntriesLocked(outbound adapter.Outbound, tag string) {
+	for _, dependency := range outbound.Dependencies() {
 		if len(m.dependByTag[dependency]) == 1 {
 			delete(m.dependByTag, dependency)
 		} else {
@@ -249,10 +257,6 @@ func (m *Manager) Remove(tag string) error {
 			})
 		}
 	}
-	if started {
-		return common.Close(outbound)
-	}
-	return nil
 }
 
 func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, inboundType string, options any) error {
@@ -286,6 +290,9 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 		if existsIndex != -1 {
 			m.outbounds = append(m.outbounds[:existsIndex], m.outbounds[existsIndex+1:]...)
 		}
+		// The replacement may declare different dependencies; drop the old
+		// outbound's dependBy entries so stale ones can't block Remove later.
+		m.removeDependByEntriesLocked(existsOutbound, tag)
 	}
 	m.outbounds = append(m.outbounds, outbound)
 	m.outboundByTag[tag] = outbound

--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -210,12 +210,17 @@ func (m *Manager) Remove(tag string) error {
 	if !found {
 		return os.ErrInvalid
 	}
-	delete(m.outboundByTag, tag)
 	index := common.Index(m.outbounds, func(it adapter.Outbound) bool {
 		return it == outbound
 	})
+	delete(m.outboundByTag, tag)
 	if index == -1 {
-		panic("invalid inbound index")
+		// Close() nils the outbounds slice but leaves outboundByTag populated,
+		// so a removal racing shutdown finds the tag with no slice entry. The
+		// outbound is already closed (or being closed) by Close(); dropping
+		// the map entry is all that's left to do.
+		m.logger.Debug("outbound/", outbound.Type(), "[", tag, "] already removed from active list")
+		return nil
 	}
 	m.outbounds = append(m.outbounds[:index], m.outbounds[index+1:]...)
 	started := m.started
@@ -275,10 +280,9 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 		existsIndex := common.Index(m.outbounds, func(it adapter.Outbound) bool {
 			return it == existsOutbound
 		})
-		if existsIndex == -1 {
-			panic("invalid inbound index")
+		if existsIndex != -1 {
+			m.outbounds = append(m.outbounds[:existsIndex], m.outbounds[existsIndex+1:]...)
 		}
-		m.outbounds = append(m.outbounds[:existsIndex], m.outbounds[existsIndex+1:]...)
 	}
 	m.outbounds = append(m.outbounds, outbound)
 	m.outboundByTag[tag] = outbound

--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -168,8 +168,14 @@ func (m *Manager) Close() error {
 	outbounds := m.outbounds
 	m.outbounds = nil
 	// Keep the map in sync with the slice: leaving stale entries behind is
-	// what made Remove racing Close find a tag with no slice entry.
+	// what made Remove racing Close find a tag with no slice entry. The
+	// dependency bookkeeping goes with them. defaultOutbound is deliberately
+	// left alone: route dispatch dereferences Default() without a nil check
+	// (route/route.go), so in-flight connections racing shutdown must keep
+	// getting the stale-but-closed outbound (which fails at dial) rather
+	// than a nil (which would panic).
 	clear(m.outboundByTag)
+	clear(m.dependByTag)
 	m.access.Unlock()
 	var err error
 	for _, outbound := range outbounds {
@@ -220,11 +226,13 @@ func (m *Manager) Remove(tag string) error {
 	if index == -1 {
 		// Defense in depth: the tag is in the map but not the slice. No code
 		// path should produce this state (Close clears both together), but if
-		// it ever reappears, heal the stale map entry instead of panicking.
+		// it ever reappears, heal it instead of panicking — skip the slice
+		// splice and fall through so the rest of the bookkeeping (default
+		// outbound, dependency entries, close) still runs.
 		m.logger.Debug("outbound/", outbound.Type(), "[", tag, "] already removed from active list")
-		return nil
+	} else {
+		m.outbounds = append(m.outbounds[:index], m.outbounds[index+1:]...)
 	}
-	m.outbounds = append(m.outbounds[:index], m.outbounds[index+1:]...)
 	started := m.started
 	if m.defaultOutbound == outbound {
 		if len(m.outbounds) > 0 {

--- a/adapter/outbound/manager_test.go
+++ b/adapter/outbound/manager_test.go
@@ -5,23 +5,37 @@ import (
 	"net"
 	"testing"
 
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing/common/logger"
 	M "github.com/sagernet/sing/common/metadata"
 )
 
 type stubOutbound struct {
-	tag string
+	tag  string
+	deps []string
 }
 
 func (s *stubOutbound) Type() string           { return "stub" }
 func (s *stubOutbound) Tag() string            { return s.tag }
 func (s *stubOutbound) Network() []string      { return nil }
-func (s *stubOutbound) Dependencies() []string { return nil }
+func (s *stubOutbound) Dependencies() []string { return s.deps }
 func (s *stubOutbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
 	return nil, nil
 }
 func (s *stubOutbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
 	return nil, nil
+}
+
+// stubRegistry hands back a preconfigured outbound from CreateOutbound; every
+// other OutboundRegistry method panics via the embedded nil interface.
+type stubRegistry struct {
+	adapter.OutboundRegistry
+	out adapter.Outbound
+}
+
+func (r *stubRegistry) CreateOutbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, outboundType string, options any) (adapter.Outbound, error) {
+	return r.out, nil
 }
 
 // Close() used to nil the outbounds slice while leaving outboundByTag
@@ -58,6 +72,28 @@ func TestRemoveHealsDesync(t *testing.T) {
 	}
 	if _, found := m.outboundByTag["test-out"]; found {
 		t.Fatal("stale outboundByTag entry not cleaned up")
+	}
+}
+
+// Replacing an outbound via Create must drop the old outbound's dependByTag
+// entries; otherwise a stale "is depended by" record blocks removing the
+// dependency later.
+func TestCreateReplaceCleansDependByTag(t *testing.T) {
+	reg := &stubRegistry{}
+	m := NewManager(logger.NOP(), reg, nil, "")
+	parent := &stubOutbound{tag: "parent"}
+	child := &stubOutbound{tag: "child", deps: []string{"parent"}}
+	m.outbounds = append(m.outbounds, parent, child)
+	m.outboundByTag["parent"] = parent
+	m.outboundByTag["child"] = child
+	m.dependByTag["parent"] = []string{"child"}
+
+	reg.out = &stubOutbound{tag: "child"} // replacement drops the dependency
+	if err := m.Create(context.Background(), nil, nil, "child", "stub", nil); err != nil {
+		t.Fatalf("Create replace: %v", err)
+	}
+	if err := m.Remove("parent"); err != nil {
+		t.Fatalf("Remove(parent) blocked by stale dependBy entry: %v", err)
 	}
 }
 

--- a/adapter/outbound/manager_test.go
+++ b/adapter/outbound/manager_test.go
@@ -24,9 +24,9 @@ func (s *stubOutbound) ListenPacket(ctx context.Context, destination M.Socksaddr
 	return nil, nil
 }
 
-// Close() nils the outbounds slice but leaves outboundByTag populated, so a
-// Remove racing shutdown used to hit panic("invalid inbound index"). It must
-// instead drop the stale map entry and return nil.
+// Close() used to nil the outbounds slice while leaving outboundByTag
+// populated, so a Remove racing shutdown hit panic("invalid inbound index").
+// Close must now clear both, and Remove must report the tag as gone.
 func TestRemoveAfterClose(t *testing.T) {
 	m := NewManager(logger.NOP(), nil, nil, "")
 	out := &stubOutbound{tag: "test-out"}
@@ -37,14 +37,27 @@ func TestRemoveAfterClose(t *testing.T) {
 	if err := m.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+	if len(m.outboundByTag) != 0 {
+		t.Fatal("Close must clear outboundByTag along with the slice")
+	}
+	if err := m.Remove("test-out"); err == nil {
+		t.Fatal("Remove after Close should report the tag as gone")
+	}
+}
+
+// Defense in depth: even if the map and slice somehow desync again (tag in
+// outboundByTag with no slice entry), Remove must heal the stale map entry
+// instead of panicking.
+func TestRemoveHealsDesync(t *testing.T) {
+	m := NewManager(logger.NOP(), nil, nil, "")
+	out := &stubOutbound{tag: "test-out"}
+	m.outboundByTag[out.Tag()] = out
+
 	if err := m.Remove("test-out"); err != nil {
-		t.Fatalf("Remove after Close: %v", err)
+		t.Fatalf("Remove on desynced manager: %v", err)
 	}
 	if _, found := m.outboundByTag["test-out"]; found {
 		t.Fatal("stale outboundByTag entry not cleaned up")
-	}
-	if err := m.Remove("test-out"); err == nil {
-		t.Fatal("second Remove should report the tag as gone")
 	}
 }
 

--- a/adapter/outbound/manager_test.go
+++ b/adapter/outbound/manager_test.go
@@ -1,0 +1,66 @@
+package outbound
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+)
+
+type stubOutbound struct {
+	tag string
+}
+
+func (s *stubOutbound) Type() string           { return "stub" }
+func (s *stubOutbound) Tag() string            { return s.tag }
+func (s *stubOutbound) Network() []string      { return nil }
+func (s *stubOutbound) Dependencies() []string { return nil }
+func (s *stubOutbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	return nil, nil
+}
+func (s *stubOutbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return nil, nil
+}
+
+// Close() nils the outbounds slice but leaves outboundByTag populated, so a
+// Remove racing shutdown used to hit panic("invalid inbound index"). It must
+// instead drop the stale map entry and return nil.
+func TestRemoveAfterClose(t *testing.T) {
+	m := NewManager(logger.NOP(), nil, nil, "")
+	out := &stubOutbound{tag: "test-out"}
+	m.outbounds = append(m.outbounds, out)
+	m.outboundByTag[out.Tag()] = out
+	m.started = true
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := m.Remove("test-out"); err != nil {
+		t.Fatalf("Remove after Close: %v", err)
+	}
+	if _, found := m.outboundByTag["test-out"]; found {
+		t.Fatal("stale outboundByTag entry not cleaned up")
+	}
+	if err := m.Remove("test-out"); err == nil {
+		t.Fatal("second Remove should report the tag as gone")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	m := NewManager(logger.NOP(), nil, nil, "")
+	out := &stubOutbound{tag: "test-out"}
+	m.outbounds = append(m.outbounds, out)
+	m.outboundByTag[out.Tag()] = out
+
+	if err := m.Remove("test-out"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(m.outbounds) != 0 {
+		t.Fatal("outbound not removed from slice")
+	}
+	if _, found := m.outboundByTag["test-out"]; found {
+		t.Fatal("outbound not removed from map")
+	}
+}


### PR DESCRIPTION
## Problem

`Manager.Close()` nils the `outbounds` slice but leaves `outboundByTag` populated (`adapter/outbound/manager.go:168-169`). Any `Remove(tag)` racing or following shutdown finds the tag in the map, gets `-1` from `common.Index` on the nil slice, and hits `panic("invalid inbound index")` at `adapter/outbound/manager.go:218`.

This is the root defect behind getlantern/engineering#3693: during the 180s `servers-updated` refresh, lantern-box's `removalQueue.checkPending` races the urltest-group teardown. The lantern-box `recover()` guard (lantern-box #80) stops the process crash but leaves the manager desynced, so every refresh fails with a 500 and forces a tunnel restart — the "VPN drops every 3 minutes" loop. On builds without the guard it crashed the proxy engine outright (the stale artifact behind now-closed getlantern/engineering#3704).

```mermaid
sequenceDiagram
    autonumber
    participant RAD as radiance<br/>config poll
    participant RQ as lantern-box removalQueue<br/>adapter/groups/manager.go
    participant MGR as sing-box Manager<br/>adapter/outbound/manager.go

    Note over RAD: servers-updated every 180s
    RAD->>MGR: tunnel teardown → Close()
    Note over MGR: manager.go:168-169<br/>m.outbounds = nil<br/>outboundByTag kept ⚠️
    RAD->>RQ: remove stale outbounds
    RQ->>MGR: manager.go:320<br/>checkPending → Remove(tag)
    rect rgba(255, 200, 200, 0.3)
        Note over MGR: manager.go:209 tag found in map<br/>manager.go:214 index == -1 in nil slice<br/>manager.go:218 panic invalid inbound index 🐛
    end
    MGR-->>RQ: panic
    Note over RQ: recover() swallows panic<br/>manager desynced, refresh fails 500
    RQ-->>RAD: 500 → tunnel restart
    Note over RAD: VPN drops every 3 min 🔁
```

## Fix

Two layers — eliminate the condition, and stop panicking if it ever reappears:

1. **Restore the invariant at the source**: `Close()` now clears the by-tag map alongside nilling the slice (both managers). An audit of every map/slice mutation (`Start` fallback, `Create`, `Remove`, `Close`) shows `Close()` was the only path that broke the "map and slice hold the same set" invariant, so the desynced state can no longer arise. `Remove` racing `Close` now gets a clean not-found.
2. **Defense in depth in `Remove`** (outbound + endpoint): resolve the slice index **before** deleting the map entry, and treat index `-1` as already-torn-down — drop the stale map entry, log at debug, return nil — instead of panicking. Same for the `Create` replace-existing paths.

## Testing

- `go test ./adapter/...` — `TestRemoveAfterClose` (Close clears the map; Remove after Close reports not-found), `TestRemoveHealsDesync` (manually-constructed desync heals instead of panicking; panics without the fix), plus happy-path `TestRemove`.
- `go build ./...` — only pre-existing `protocol/tailscale` failure on the base branch (missing sing-tun symbols, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint and outbound lifecycle handling during shutdown, removal, and replacement.
  - Prevented crashes when internal state becomes inconsistent.
  - Cleared stale endpoint, outbound, and dependency references.
  - Ensured replacements and removals correctly update associated dependency tracking.

- **Tests**
  - Added coverage for shutdown cleanup, safe removal, replacement behavior, and recovery from inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->