### PR TITLE
fix: create process searcher on live rule-set update

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sagernet/sing-mux"
-	"github.com/sagernet/sing-vmess"
+	mux "github.com/sagernet/sing-mux"
+	vmess "github.com/sagernet/sing-vmess"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
 	"github.com/sagernet/sing/common/bufio"
@@ -282,7 +282,11 @@ func (r *Router) matchRule(
 	selectedRule adapter.Rule, selectedRuleIndex int,
 	buffers []*buf.Buffer, packetBuffers []*N.PacketBuffer, fatalErr error,
 ) {
-	if searcher := r.processInfoSearcher(); searcher != nil && metadata.ProcessInfo == nil {
+	var searcher process.Searcher
+	if metadata.ProcessInfo == nil {
+		searcher = r.processInfoSearcher()
+	}
+	if searcher != nil {
 		var originDestination netip.AddrPort
 		if metadata.OriginDestination.IsValid() {
 			originDestination = metadata.OriginDestination.AddrPort()

--- a/route/route.go
+++ b/route/route.go
@@ -282,14 +282,14 @@ func (r *Router) matchRule(
 	selectedRule adapter.Rule, selectedRuleIndex int,
 	buffers []*buf.Buffer, packetBuffers []*N.PacketBuffer, fatalErr error,
 ) {
-	if r.processSearcher != nil && metadata.ProcessInfo == nil {
+	if searcher := r.processInfoSearcher(); searcher != nil && metadata.ProcessInfo == nil {
 		var originDestination netip.AddrPort
 		if metadata.OriginDestination.IsValid() {
 			originDestination = metadata.OriginDestination.AddrPort()
 		} else if metadata.Destination.IsIP() {
 			originDestination = metadata.Destination.AddrPort()
 		}
-		processInfo, fErr := process.FindProcessInfo(r.processSearcher, ctx, metadata.Network, metadata.Source.AddrPort(), originDestination)
+		processInfo, fErr := process.FindProcessInfo(searcher, ctx, metadata.Network, metadata.Source.AddrPort(), originDestination)
 		if fErr != nil {
 			r.logger.InfoContext(ctx, "failed to search process: ", fErr)
 		} else {

--- a/route/router.go
+++ b/route/router.go
@@ -4,6 +4,14 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"sync"
+	"sync/atomic"
+
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/task"
+	"github.com/sagernet/sing/common/x/list"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/common/process"
@@ -13,33 +21,32 @@ import (
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
 	R "github.com/sagernet/sing-box/route/rule"
-	E "github.com/sagernet/sing/common/exceptions"
-	"github.com/sagernet/sing/common/task"
-	"github.com/sagernet/sing/service"
-	"github.com/sagernet/sing/service/pause"
 )
 
 var _ adapter.Router = (*Router)(nil)
 
 type Router struct {
-	ctx               context.Context
-	logger            log.ContextLogger
-	inbound           adapter.InboundManager
-	outbound          adapter.OutboundManager
-	dns               adapter.DNSRouter
-	dnsTransport      adapter.DNSTransportManager
-	connection        adapter.ConnectionManager
-	network           adapter.NetworkManager
-	rules             []adapter.Rule
-	needFindProcess   bool
-	ruleSets          []adapter.RuleSet
-	ruleSetMap        map[string]adapter.RuleSet
-	processSearcher   process.Searcher
-	pauseManager      pause.Manager
-	trackers          []adapter.ConnectionTracker
-	platformInterface platform.Interface
-	needWIFIState     bool
-	started           bool
+	ctx                 context.Context
+	logger              log.ContextLogger
+	inbound             adapter.InboundManager
+	outbound            adapter.OutboundManager
+	dns                 adapter.DNSRouter
+	dnsTransport        adapter.DNSTransportManager
+	connection          adapter.ConnectionManager
+	network             adapter.NetworkManager
+	rules               []adapter.Rule
+	needFindProcess     bool
+	ruleSets            []adapter.RuleSet
+	ruleSetMap          map[string]adapter.RuleSet
+	processNeeded       atomic.Bool
+	processSearcher     process.Searcher
+	processSearcherOnce sync.Once
+	processCallbacks    []*list.Element[adapter.RuleSetUpdateCallback]
+	pauseManager        pause.Manager
+	trackers            []adapter.ConnectionTracker
+	platformInterface   platform.Interface
+	needWIFIState       bool
+	started             bool
 }
 
 func NewRouter(ctx context.Context, logFactory log.Factory, options option.RouteOptions, dnsOptions option.DNSOptions) *Router {
@@ -113,34 +120,20 @@ func (r *Router) Start(stage adapter.StartStage) error {
 		if cacheContext != nil {
 			cacheContext.Close()
 		}
-		needFindProcess := r.needFindProcess
 		for _, ruleSet := range r.ruleSets {
-			metadata := ruleSet.Metadata()
-			if metadata.ContainsProcessRule {
-				needFindProcess = true
-			}
-			if metadata.ContainsWIFIRule {
+			if ruleSet.Metadata().ContainsWIFIRule {
 				r.needWIFIState = true
 			}
+			element := ruleSet.RegisterCallback(func(adapter.RuleSet) {
+				r.updateProcessNeeded()
+			})
+			r.processCallbacks = append(r.processCallbacks, element)
 		}
-		if needFindProcess {
-			if r.platformInterface != nil {
-				r.processSearcher = r.platformInterface
-			} else {
-				monitor.Start("initialize process searcher")
-				searcher, err := process.NewSearcher(process.Config{
-					Logger:         r.logger,
-					PackageManager: r.network.PackageManager(),
-				})
-				monitor.Finish()
-				if err != nil {
-					if err != os.ErrInvalid {
-						r.logger.Warn(E.Cause(err, "create process searcher"))
-					}
-				} else {
-					r.processSearcher = searcher
-				}
-			}
+		r.updateProcessNeeded()
+		if r.processNeeded.Load() {
+			monitor.Start("initialize process searcher")
+			r.processInfoSearcher()
+			monitor.Finish()
 		}
 	case adapter.StartStatePostStart:
 		for i, rule := range r.rules {
@@ -170,6 +163,43 @@ func (r *Router) Start(stage adapter.StartStage) error {
 	return nil
 }
 
+func (r *Router) updateProcessNeeded() {
+	need := r.needFindProcess
+	if !need {
+		for _, ruleSet := range r.ruleSets {
+			if ruleSet.Metadata().ContainsProcessRule {
+				need = true
+				break
+			}
+		}
+	}
+	r.processNeeded.Store(need)
+}
+
+func (r *Router) processInfoSearcher() process.Searcher {
+	if !r.processNeeded.Load() {
+		return nil
+	}
+	r.processSearcherOnce.Do(func() {
+		if r.platformInterface != nil {
+			r.processSearcher = r.platformInterface
+			return
+		}
+		searcher, err := process.NewSearcher(process.Config{
+			Logger:         r.logger,
+			PackageManager: r.network.PackageManager(),
+		})
+		if err != nil {
+			if err != os.ErrInvalid {
+				r.logger.Warn(E.Cause(err, "create process searcher"))
+			}
+			return
+		}
+		r.processSearcher = searcher
+	})
+	return r.processSearcher
+}
+
 func (r *Router) Close() error {
 	monitor := taskmonitor.New(r.logger, C.StopTimeout)
 	var err error
@@ -181,6 +211,9 @@ func (r *Router) Close() error {
 		monitor.Finish()
 	}
 	for i, ruleSet := range r.ruleSets {
+		if i < len(r.processCallbacks) {
+			ruleSet.UnregisterCallback(r.processCallbacks[i])
+		}
 		monitor.Start("close rule-set[", i, "]")
 		err = E.Append(err, ruleSet.Close(), func(err error) error {
 			return E.Cause(err, "close rule-set[", i, "]")

--- a/route/router.go
+++ b/route/router.go
@@ -38,10 +38,11 @@ type Router struct {
 	needFindProcess     bool
 	ruleSets            []adapter.RuleSet
 	ruleSetMap          map[string]adapter.RuleSet
+	processNeededMutex  sync.Mutex
 	processNeeded       atomic.Bool
 	processSearcher     process.Searcher
 	processSearcherOnce sync.Once
-	processCallbacks    []*list.Element[adapter.RuleSetUpdateCallback]
+	processCallbacks    map[adapter.RuleSet]*list.Element[adapter.RuleSetUpdateCallback]
 	pauseManager        pause.Manager
 	trackers            []adapter.ConnectionTracker
 	platformInterface   platform.Interface
@@ -61,6 +62,7 @@ func NewRouter(ctx context.Context, logFactory log.Factory, options option.Route
 		network:           service.FromContext[adapter.NetworkManager](ctx),
 		rules:             make([]adapter.Rule, 0, len(options.Rules)),
 		ruleSetMap:        make(map[string]adapter.RuleSet),
+		processCallbacks:  make(map[adapter.RuleSet]*list.Element[adapter.RuleSetUpdateCallback]),
 		needFindProcess:   hasRule(options.Rules, isProcessRule) || hasDNSRule(dnsOptions.Rules, isProcessDNSRule) || options.FindProcess,
 		pauseManager:      service.FromContext[pause.Manager](ctx),
 		platformInterface: service.FromContext[platform.Interface](ctx),
@@ -127,7 +129,7 @@ func (r *Router) Start(stage adapter.StartStage) error {
 			element := ruleSet.RegisterCallback(func(adapter.RuleSet) {
 				r.updateProcessNeeded()
 			})
-			r.processCallbacks = append(r.processCallbacks, element)
+			r.processCallbacks[ruleSet] = element
 		}
 		r.updateProcessNeeded()
 		if r.processNeeded.Load() {
@@ -164,6 +166,9 @@ func (r *Router) Start(stage adapter.StartStage) error {
 }
 
 func (r *Router) updateProcessNeeded() {
+	r.processNeededMutex.Lock()
+	defer r.processNeededMutex.Unlock()
+
 	need := r.needFindProcess
 	if !need {
 		for _, ruleSet := range r.ruleSets {
@@ -211,8 +216,8 @@ func (r *Router) Close() error {
 		monitor.Finish()
 	}
 	for i, ruleSet := range r.ruleSets {
-		if i < len(r.processCallbacks) {
-			ruleSet.UnregisterCallback(r.processCallbacks[i])
+		if element, ok := r.processCallbacks[ruleSet]; ok {
+			ruleSet.UnregisterCallback(element)
 		}
 		monitor.Start("close rule-set[", i, "]")
 		err = E.Append(err, ruleSet.Close(), func(err error) error {


### PR DESCRIPTION
## Problem

The process-info searcher was decided exactly once, during `StartStateStart`, from a snapshot of the static config need OR'd with each rule-set's `ContainsProcessRule` metadata; the connection match path then gated on the resulting `processSearcher != nil`.

Remote and local rule-sets can update live, and an update can introduce a process rule where none existed at startup. When that happened, no searcher was ever created, so the newly-added process rules silently stopped matching until a full app restart — even though both rule-set types already recompute `ContainsProcessRule` and fire `RuleSetUpdateCallback`s on update. Nothing consumed those callbacks for this purpose.

## Fix

- Maintain a dynamic `processNeeded` (`atomic.Bool`) recomputed from the static config need plus every rule-set's live metadata, updated via `RuleSetUpdateCallback`s registered on each rule-set at start.
- Construct the searcher lazily and at most once (`sync.Once`) via `processInfoSearcher()`, either eagerly at startup (preserving today's monitored init when a process rule already exists) or on the first connection that needs it after an update.
- Callbacks only flip the flag — construction never runs on a rule-set update goroutine, avoiding races and keeping the Windows `LoadExtendedTable` init off the fetch path.
- Callbacks are unregistered in `Close`.

The match-path gate in `route/route.go` now calls `processInfoSearcher()` instead of reading the startup-snapshot field.

> [!NOTE] 
An issue was also created in the [sing-box](https://github.com/SagerNet/sing-box/issues/4341), with an offer to submit a PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Process-based routing resources are now initialized only when rule sets require process searching, reducing unnecessary startup work.
- **Reliability**
  - Process searcher initialization is concurrency-safe and happens lazily.
  - Rule-set process-search requirements update automatically at runtime, and callbacks are cleaned up properly on shutdown.
- **Bug Fixes**
  - Process information matching now derives missing process context at runtime and improves handling of origin/destination metadata, with correct fallback behavior for destination IP cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->