### PR TITLE
make process name and path rule case-insensitive on windows

### DIFF
--- a/route/rule/rule_item_process_name.go
+++ b/route/rule/rule_item_process_name.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
 )
 
 var _ RuleItem = (*ProcessItem)(nil)
@@ -20,6 +21,9 @@ func NewProcessItem(processNameList []string) *ProcessItem {
 		processMap: make(map[string]bool),
 	}
 	for _, processName := range processNameList {
+		if C.IsWindows {
+			processName = strings.ToLower(processName)
+		}
 		rule.processMap[processName] = true
 	}
 	return rule
@@ -29,7 +33,11 @@ func (r *ProcessItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil || metadata.ProcessInfo.ProcessPath == "" {
 		return false
 	}
-	return r.processMap[filepath.Base(metadata.ProcessInfo.ProcessPath)]
+	path := filepath.Base(metadata.ProcessInfo.ProcessPath)
+	if C.IsWindows {
+		path = strings.ToLower(path)
+	}
+	return r.processMap[path]
 }
 
 func (r *ProcessItem) String() string {

--- a/route/rule/rule_item_process_name.go
+++ b/route/rule/rule_item_process_name.go
@@ -33,11 +33,11 @@ func (r *ProcessItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil || metadata.ProcessInfo.ProcessPath == "" {
 		return false
 	}
-	path := filepath.Base(metadata.ProcessInfo.ProcessPath)
+	name := filepath.Base(metadata.ProcessInfo.ProcessPath)
 	if C.IsWindows {
-		path = strings.ToLower(path)
+		name = strings.ToLower(name)
 	}
-	return r.processMap[path]
+	return r.processMap[name]
 }
 
 func (r *ProcessItem) String() string {

--- a/route/rule/rule_item_process_path.go
+++ b/route/rule/rule_item_process_path.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
 )
 
 var _ RuleItem = (*ProcessPathItem)(nil)
@@ -19,6 +20,9 @@ func NewProcessPathItem(processNameList []string) *ProcessPathItem {
 		processMap: make(map[string]bool),
 	}
 	for _, processName := range processNameList {
+		if C.IsWindows {
+			processName = strings.ToLower(processName)
+		}
 		rule.processMap[processName] = true
 	}
 	return rule
@@ -28,7 +32,11 @@ func (r *ProcessPathItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil || metadata.ProcessInfo.ProcessPath == "" {
 		return false
 	}
-	return r.processMap[metadata.ProcessInfo.ProcessPath]
+	path := metadata.ProcessInfo.ProcessPath
+	if C.IsWindows {
+		path = strings.ToLower(path)
+	}
+	return r.processMap[path]
 }
 
 func (r *ProcessPathItem) String() string {


### PR DESCRIPTION
This PR implements case-insensitive process name and path matching for rule sets on Windows.

Windows file system paths are case-insensitive, and different APIs or mechanisms for retrieving an executable's path may return it with different letter casing rather than its canonical form. Performing case-insensitive comparisons ensures rule matching is consistent regardless of how the process name or executable path is reported.

I've already submitted an issue for it in sing-box, and offered to open a PR — still waiting for a response. In the meantime, we can patch it here so we can push it out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process name and process path rule matching on Windows by handling differences in letter casing.
  * Matching now works consistently regardless of whether configured values or detected process information use uppercase or lowercase letters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->