### PR TITLE
adapter: stop Create from leaking on its error paths

### DIFF
--- a/adapter/endpoint/manager.go
+++ b/adapter/endpoint/manager.go
@@ -130,15 +130,22 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 		for _, stage := range adapter.ListStartStages {
 			err = adapter.LegacyStart(endpoint, stage)
 			if err != nil {
+				// Never reaches the registry maps on this path, so nothing else can
+				// close it. Release what the earlier stages brought up.
+				if closeErr := common.Close(endpoint); closeErr != nil {
+					m.logger.Warn("close partially started endpoint/", endpoint.Type(), "[", endpoint.Tag(), "]: ", closeErr)
+				}
 				return E.Cause(err, stage, " endpoint/", endpoint.Type(), "[", endpoint.Tag(), "]")
 			}
 		}
 	}
 	if existsEndpoint, loaded := m.endpointByTag[tag]; loaded {
 		if m.started {
-			err = existsEndpoint.Close()
-			if err != nil {
-				return E.Cause(err, "close endpoint/", existsEndpoint.Type(), "[", existsEndpoint.Tag(), "]")
+			// Log rather than abort: the predecessor is discarded either way, and
+			// returning here would leave it registered-but-closed while the
+			// replacement, already started, is never registered.
+			if closeErr := existsEndpoint.Close(); closeErr != nil {
+				m.logger.Warn("close endpoint/", existsEndpoint.Type(), "[", existsEndpoint.Tag(), "]: ", closeErr)
 			}
 		}
 		existsIndex := common.Index(m.endpoints, func(it adapter.Endpoint) bool {

--- a/adapter/inbound/manager.go
+++ b/adapter/inbound/manager.go
@@ -124,15 +124,22 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 		for _, stage := range adapter.ListStartStages {
 			err = adapter.LegacyStart(inbound, stage)
 			if err != nil {
+				// Never reaches the registry maps on this path, so nothing else can
+				// close it. Release what the earlier stages brought up.
+				if closeErr := common.Close(inbound); closeErr != nil {
+					m.logger.Warn("close partially started inbound/", inbound.Type(), "[", inbound.Tag(), "]: ", closeErr)
+				}
 				return E.Cause(err, stage, " inbound/", inbound.Type(), "[", inbound.Tag(), "]")
 			}
 		}
 	}
 	if existsInbound, loaded := m.inboundByTag[tag]; loaded {
 		if m.started {
-			err = existsInbound.Close()
-			if err != nil {
-				return E.Cause(err, "close inbound/", existsInbound.Type(), "[", existsInbound.Tag(), "]")
+			// Log rather than abort: the predecessor is discarded either way, and
+			// returning here would leave it registered-but-closed while the
+			// replacement, already started, is never registered.
+			if closeErr := existsInbound.Close(); closeErr != nil {
+				m.logger.Warn("close inbound/", existsInbound.Type(), "[", existsInbound.Tag(), "]: ", closeErr)
 			}
 		}
 		existsIndex := common.Index(m.inbounds, func(it adapter.Inbound) bool {

--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -275,10 +275,21 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 	if err != nil {
 		return err
 	}
+	// The replacement starts before the predecessor closes (make before break), so
+	// a replacement that fails to start leaves the existing outbound serving this
+	// tag rather than dropping it. The cost is a transient window where both are
+	// live, which is why teardown has to be prompt.
 	if m.started {
 		for _, stage := range adapter.ListStartStages {
 			err = adapter.LegacyStart(outbound, stage)
 			if err != nil {
+				// This outbound never reaches m.outbounds/outboundByTag on the error
+				// path, so nothing else can ever close it. Release whatever the
+				// earlier stages brought up before returning, or it leaks for the
+				// lifetime of the process.
+				if closeErr := common.Close(outbound); closeErr != nil {
+					m.logger.Warn("close partially started outbound/", outbound.Type(), "[", outbound.Tag(), "]: ", closeErr)
+				}
 				return E.Cause(err, stage, " outbound/", outbound.Type(), "[", outbound.Tag(), "]")
 			}
 		}
@@ -287,9 +298,12 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 	defer m.access.Unlock()
 	if existsOutbound, loaded := m.outboundByTag[tag]; loaded {
 		if m.started {
-			err = common.Close(existsOutbound)
-			if err != nil {
-				return E.Cause(err, "close outbound/", existsOutbound.Type(), "[", existsOutbound.Tag(), "]")
+			// Log rather than abort. The predecessor is being discarded either way,
+			// and returning here would leave it registered-but-closed while the
+			// replacement — already fully started — never gets registered, and so
+			// could never be closed either.
+			if closeErr := common.Close(existsOutbound); closeErr != nil {
+				m.logger.Warn("close outbound/", existsOutbound.Type(), "[", existsOutbound.Tag(), "]: ", closeErr)
 			}
 		}
 		existsIndex := common.Index(m.outbounds, func(it adapter.Outbound) bool {

--- a/adapter/outbound/manager_test.go
+++ b/adapter/outbound/manager_test.go
@@ -2,6 +2,7 @@ package outbound
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
@@ -111,5 +112,106 @@ func TestRemove(t *testing.T) {
 	}
 	if _, found := m.outboundByTag["test-out"]; found {
 		t.Fatal("outbound not removed from map")
+	}
+}
+
+// lifecycleOutbound is a stubOutbound that participates in the start-stage
+// lifecycle, so a test can fail a chosen stage and observe whether Create
+// cleaned up after itself.
+type lifecycleOutbound struct {
+	stubOutbound
+	failStage  *adapter.StartStage // stage to fail at, nil to always succeed
+	closeErr   error
+	started    []adapter.StartStage
+	closeCalls int
+}
+
+func (l *lifecycleOutbound) Start(stage adapter.StartStage) error {
+	if l.failStage != nil && stage == *l.failStage {
+		return errors.New("stage failed")
+	}
+	l.started = append(l.started, stage)
+	return nil
+}
+
+func (l *lifecycleOutbound) Close() error {
+	l.closeCalls++
+	return l.closeErr
+}
+
+// A replacement that fails partway through its start stages never reaches
+// m.outbounds or outboundByTag, so nothing else can ever close it. Create must
+// release the stages that did come up, or every failed start leaks whatever the
+// outbound allocated (for unbounded, a whole broflake/WebRTC stack).
+func TestCreateClosesOutboundOnStartFailure(t *testing.T) {
+	t.Parallel()
+
+	failAt := adapter.StartStateStarted // last stage, so the earlier three ran
+	out := &lifecycleOutbound{stubOutbound: stubOutbound{tag: "flaky"}, failStage: &failAt}
+
+	m := NewManager(logger.NOP(), &stubRegistry{out: out}, nil, "")
+	m.started = true
+
+	err := m.Create(context.Background(), nil, nil, "flaky", "stub", nil)
+	if err == nil {
+		t.Fatal("Create should surface the start-stage failure")
+	}
+	if out.closeCalls != 1 {
+		t.Fatalf("partially started outbound was not closed (closeCalls=%d); its resources leak "+
+			"because it is never registered and so can never be closed later", out.closeCalls)
+	}
+	if _, found := m.outboundByTag["flaky"]; found {
+		t.Fatal("an outbound that failed to start must not be registered")
+	}
+	if len(m.outbounds) != 0 {
+		t.Fatalf("an outbound that failed to start must not be in the active list (len=%d)", len(m.outbounds))
+	}
+}
+
+// Create used to abort when closing the predecessor returned an error, which
+// left the manager inconsistent: the predecessor stayed registered despite
+// having been closed, while the replacement — already fully started — was never
+// registered and so could never be closed. The swap has to complete.
+func TestCreateCompletesSwapWhenPredecessorCloseFails(t *testing.T) {
+	t.Parallel()
+
+	old := &lifecycleOutbound{stubOutbound: stubOutbound{tag: "dup"}, closeErr: errors.New("close failed")}
+	replacement := &lifecycleOutbound{stubOutbound: stubOutbound{tag: "dup"}}
+
+	m := NewManager(logger.NOP(), &stubRegistry{out: replacement}, nil, "")
+	m.started = true
+	m.outbounds = append(m.outbounds, old)
+	m.outboundByTag["dup"] = old
+
+	if err := m.Create(context.Background(), nil, nil, "dup", "stub", nil); err != nil {
+		t.Fatalf("Create must not fail because the predecessor's Close did: %v", err)
+	}
+	if old.closeCalls != 1 {
+		t.Fatalf("predecessor not closed (closeCalls=%d)", old.closeCalls)
+	}
+	if got := m.outboundByTag["dup"]; got != adapter.Outbound(replacement) {
+		t.Fatalf("tag still maps to the closed predecessor: %#v", got)
+	}
+	if len(m.outbounds) != 1 || m.outbounds[0] != adapter.Outbound(replacement) {
+		t.Fatalf("active list not swapped: len=%d", len(m.outbounds))
+	}
+}
+
+// The happy path must still run every stage and leave the outbound open.
+func TestCreateRunsAllStartStages(t *testing.T) {
+	t.Parallel()
+
+	out := &lifecycleOutbound{stubOutbound: stubOutbound{tag: "ok"}}
+	m := NewManager(logger.NOP(), &stubRegistry{out: out}, nil, "")
+	m.started = true
+
+	if err := m.Create(context.Background(), nil, nil, "ok", "stub", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(out.started) != len(adapter.ListStartStages) {
+		t.Fatalf("ran %d of %d start stages", len(out.started), len(adapter.ListStartStages))
+	}
+	if out.closeCalls != 0 {
+		t.Fatalf("a successfully started outbound must not be closed (closeCalls=%d)", out.closeCalls)
 	}
 }

--- a/adapter/service/manager.go
+++ b/adapter/service/manager.go
@@ -119,15 +119,22 @@ func (m *Manager) Create(ctx context.Context, logger log.ContextLogger, tag stri
 		for _, stage := range adapter.ListStartStages {
 			err = adapter.LegacyStart(service, stage)
 			if err != nil {
+				// Never reaches the registry maps on this path, so nothing else can
+				// close it. Release what the earlier stages brought up.
+				if closeErr := common.Close(service); closeErr != nil {
+					m.logger.Warn("close partially started service/", service.Type(), "[", service.Tag(), "]: ", closeErr)
+				}
 				return E.Cause(err, stage, " service/", service.Type(), "[", service.Tag(), "]")
 			}
 		}
 	}
 	if existsService, loaded := m.serviceByTag[tag]; loaded {
 		if m.started {
-			err = existsService.Close()
-			if err != nil {
-				return E.Cause(err, "close service/", existsService.Type(), "[", existsService.Tag(), "]")
+			// Log rather than abort: the predecessor is discarded either way, and
+			// returning here would leave it registered-but-closed while the
+			// replacement, already started, is never registered.
+			if closeErr := existsService.Close(); closeErr != nil {
+				m.logger.Warn("close service/", existsService.Type(), "[", existsService.Tag(), "]: ", closeErr)
 			}
 		}
 		existsIndex := common.Index(m.services, func(it adapter.Service) bool {


### PR DESCRIPTION
## Problem

`Manager.Create` has two error-path defects, present **identically in all four managers** — `outbound`, `endpoint`, `inbound`, `service`:

**1. A start-stage failure leaks the object.**

```go
for _, stage := range adapter.ListStartStages {
    if err = adapter.LegacyStart(outbound, stage); err != nil {
        return E.Cause(err, ...)   // ← never closed
    }
}
```

There are four stages (`initialize`, `start`, `post-start`, `finish-start`). A failure at stage *n* leaves stages `1..n-1` running, and this path never reaches `m.outbounds` / `m.outboundByTag` — so nothing else can ever close it. Every failed start leaks whatever the earlier stages allocated, for the lifetime of the process. For the `unbounded` outbound that is an entire broflake/WebRTC stack, because it comes up during `post-start`.

**2. A predecessor close failure aborts mid-swap.**

```go
if existsOutbound, loaded := m.outboundByTag[tag]; loaded {
    if m.started {
        if err = common.Close(existsOutbound); err != nil {
            return E.Cause(err, ...)   // ← manager left inconsistent
        }
    }
```

Returning here leaves the predecessor **registered despite having been closed** — so dispatch keeps routing to a closed object — while the replacement, already fully started, is never registered and so can never be closed either. One error leaks one object *and* corrupts the routing table.

## Changes

- Close the partially started object before returning the start error, logging any close failure.
- Log the predecessor's close error and complete the swap. The predecessor is discarded either way, and this matches how `Remove` and `Close` already treat cleanup errors (`Remove` logs its desync-heal; `Close` accumulates close errors without failing).

## On the ordering — deliberately unchanged

The start-before-close sequence was the original suspicion (it is root cause #2 of getlantern/engineering#3698), but it is **make-before-break** and worth keeping: a replacement that fails to start leaves the existing outbound serving the tag rather than dropping it. Flipping to break-before-make would trade a transient overlap for an availability hole on every failed start.

Its real cost is that the overlap window is only as short as teardown is prompt — which is what getlantern/unbounded#412 fixed (a broflake worker parked in an uncancellable send used to strand the whole stack indefinitely). The ordering is now documented in place so the next reader does not "fix" it into break-before-make.

## Testing

Three tests in `adapter/outbound/manager_test.go`, extending the existing `stubOutbound`/`stubRegistry` scaffold with a `lifecycleOutbound` that can fail a chosen stage and count `Close` calls:

| test | asserts |
|---|---|
| `TestCreateClosesOutboundOnStartFailure` | the partially started outbound is closed and left unregistered |
| `TestCreateCompletesSwapWhenPredecessorCloseFails` | `Create` succeeds, the tag maps to the replacement, the active list is swapped |
| `TestCreateRunsAllStartStages` | happy path runs all four stages and does **not** close |

Both regression tests were verified to fail against `lantern-main`:

```
TestCreateClosesOutboundOnStartFailure: partially started outbound was not closed (closeCalls=0)
TestCreateCompletesSwapWhenPredecessorCloseFails: Create must not fail because the predecessor's Close did
```

`go build ./adapter/...`, `go vet ./adapter/...`, `go test ./adapter/...` all pass. `golangci-lint run --new-from-rev=origin/lantern-main ./adapter/...` reports **0 issues**.

## Scope notes

- Only the `outbound` manager has a test file; the three siblings get the same fix without new tests, since the code is line-for-line identical.
- `t.Parallel()` added to the new tests only. The four pre-existing `paralleltest` violations in that file are left alone.
- **Follow-up, not fixed here:** `inbound/manager.go:105,142` and `service/manager.go:100,137` still `panic("invalid <kind> index")` on a map/slice desync. getlantern/sing-box-minimal#51 replaced exactly that panic with a heal-and-log in the outbound manager; the siblings never got it.
- `protocol/tailscale` fails a plain `go build ./...` (`undefined: tun.DefaultNIC`) on `lantern-main` already — it needs the `with_gvisor` tag that CI and `.golangci.yml` set. Unrelated to this change.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none (no findings raised)
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting endpoints, inbound adapters, outbound adapters, and services.
  * Partially initialized components are now cleaned up automatically when startup fails.
  * Replacing a running component now proceeds even if the previous component reports a shutdown error.
  * Cleanup and shutdown errors are recorded while preserving the original startup failure details.
  * Prevented failed components from remaining registered after unsuccessful startup.

* **Tests**
  * Added coverage for startup failures, cleanup behavior, and replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->